### PR TITLE
Added BuiltResult.matchNotBuilt for Result.NOT_BUILT

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pipeline {
             ],
             [
                 conditions: [
-                    BuildResult(matchAborted: true, matchFailure: true, matchUnstable: true)
+                    BuildResult(matchNotBuilt: true, matchAborted: true, matchFailure: true, matchUnstable: true)
                 ],
                 actions: [DeleteBuild()]
             ]

--- a/src/main/java/pl/damianszczepanik/jenkins/buildhistorymanager/model/conditions/BuildResultCondition.java
+++ b/src/main/java/pl/damianszczepanik/jenkins/buildhistorymanager/model/conditions/BuildResultCondition.java
@@ -17,6 +17,7 @@ public class BuildResultCondition extends Condition {
     private boolean matchUnstable;
     private boolean matchFailure;
     private boolean matchAborted;
+    private boolean matchNotBuilt;
 
     @DataBoundConstructor
     public BuildResultCondition() {
@@ -59,6 +60,15 @@ public class BuildResultCondition extends Condition {
         this.matchAborted = matchAborted;
     }
 
+    public boolean getMatchNotBuilt() {
+        return matchNotBuilt;
+    }
+
+    @DataBoundSetter
+    public void setMatchNotBuilt(boolean matchNotBuilt) {
+        this.matchNotBuilt = matchNotBuilt;
+    }
+
     @Override
     public boolean matches(Run<?, ?> run, RuleConfiguration configuration) {
         Result result = run.getResult();
@@ -72,6 +82,9 @@ public class BuildResultCondition extends Condition {
             return true;
         }
         if (matchAborted && result == Result.ABORTED) {
+            return true;
+        }
+        if (matchNotBuilt && result == Result.NOT_BUILT) {
             return true;
         }
         return false;

--- a/src/main/resources/pl/damianszczepanik/jenkins/buildhistorymanager/model/conditions/BuildResultCondition/config.jelly
+++ b/src/main/resources/pl/damianszczepanik/jenkins/buildhistorymanager/model/conditions/BuildResultCondition/config.jelly
@@ -13,5 +13,8 @@
     <f:entry title="Aborted result" field="matchAborted">
         <f:checkbox default="false"/>
     </f:entry>
+    <f:entry title="Not Built result" field="matchNotBuilt">
+        <f:checkbox default="false"/>
+    </f:entry>
 
 </j:jelly>

--- a/src/test/java/pl/damianszczepanik/jenkins/buildhistorymanager/model/conditions/BuildResultConditionTest.java
+++ b/src/test/java/pl/damianszczepanik/jenkins/buildhistorymanager/model/conditions/BuildResultConditionTest.java
@@ -74,6 +74,20 @@ public class BuildResultConditionTest {
     }
 
     @Test
+    public void setMatchNotBuilt_Sets_NotBuilt() {
+
+        // given
+        BuildResultCondition condition = new BuildResultCondition();
+        boolean matchNotBuilt = true;
+
+        // when
+        condition.setMatchNotBuilt(matchNotBuilt);
+
+        // then
+        assertThat(condition.getMatchNotBuilt()).isEqualTo(matchNotBuilt);
+    }
+
+    @Test
     public void match_OnMatchSuccessAndResultSuccess_ReturnsTrue() throws IOException {
 
         // given
@@ -247,6 +261,52 @@ public class BuildResultConditionTest {
         // given
         BuildResultCondition condition = new BuildResultCondition();
         condition.setMatchAborted(true);
+        Run<?, ?> run = new RunStub(Result.FAILURE);
+
+        // when
+        boolean matched = condition.matches(run, null);
+
+        // then
+        assertThat(matched).isFalse();
+    }
+
+
+    @Test
+    public void match_OnMatchNotBuiltAndResultNotBuilt_ReturnsTrue() throws IOException {
+
+        // given
+        BuildResultCondition condition = new BuildResultCondition();
+        condition.setMatchNotBuilt(true);
+        Run<?, ?> run = new RunStub(Result.NOT_BUILT);
+
+        // when
+        boolean matched = condition.matches(run, null);
+
+        // then
+        assertThat(matched).isTrue();
+    }
+
+    @Test
+    public void match_OnNotMatchNotBuiltAndResultNotBuilt_ReturnsTrue() throws IOException {
+
+        // given
+        BuildResultCondition condition = new BuildResultCondition();
+        condition.setMatchNotBuilt(false);
+        Run<?, ?> run = new RunStub(Result.NOT_BUILT);
+
+        // when
+        boolean matched = condition.matches(run, null);
+
+        // then
+        assertThat(matched).isFalse();
+    }
+
+    @Test
+    public void match_OnMatchNotBuiltAndResultNotNotBuilt_ReturnsTrue() throws IOException {
+
+        // given
+        BuildResultCondition condition = new BuildResultCondition();
+        condition.setMatchNotBuilt(true);
         Run<?, ?> run = new RunStub(Result.FAILURE);
 
         // when


### PR DESCRIPTION
Per https://javadoc.jenkins-ci.org/hudson/model/Result.html#NOT_BUILT there are five possible build result statuses.  Added the missing NOT_BUILT as `BuildResult.matchNotBuilt`.

This resolves issue #69 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
