### PR TITLE
Also match null result on matchNotBuilt

### DIFF
--- a/src/main/java/pl/damianszczepanik/jenkins/buildhistorymanager/model/conditions/BuildResultCondition.java
+++ b/src/main/java/pl/damianszczepanik/jenkins/buildhistorymanager/model/conditions/BuildResultCondition.java
@@ -84,7 +84,7 @@ public class BuildResultCondition extends Condition {
         if (matchAborted && result == Result.ABORTED) {
             return true;
         }
-        if (matchNotBuilt && result == Result.NOT_BUILT) {
+        if (matchNotBuilt && (result == null || result == Result.NOT_BUILT)) {
             return true;
         }
         return false;

--- a/src/test/java/pl/damianszczepanik/jenkins/buildhistorymanager/model/conditions/BuildResultConditionTest.java
+++ b/src/test/java/pl/damianszczepanik/jenkins/buildhistorymanager/model/conditions/BuildResultConditionTest.java
@@ -272,6 +272,52 @@ public class BuildResultConditionTest {
 
 
     @Test
+    public void match_OnMatchNotBuiltAndResultNull_ReturnsTrue() throws IOException {
+
+        // given
+        BuildResultCondition condition = new BuildResultCondition();
+        condition.setMatchNotBuilt(true);
+        Run<?, ?> run = new RunStub();
+
+        // when
+        boolean matched = condition.matches(run, null);
+
+        // then
+        assertThat(matched).isTrue();
+    }
+
+    @Test
+    public void match_OnNotMatchNotBuiltAndResultNull_ReturnsFalse() throws IOException {
+
+        // given
+        BuildResultCondition condition = new BuildResultCondition();
+        condition.setMatchNotBuilt(false);
+        Run<?, ?> run = new RunStub();
+
+        // when
+        boolean matched = condition.matches(run, null);
+
+        // then
+        assertThat(matched).isFalse();
+    }
+
+    @Test
+    public void match_OnMatchNotBuiltAndResultNotNull_ReturnsFalse() throws IOException {
+
+        // given
+        BuildResultCondition condition = new BuildResultCondition();
+        condition.setMatchNotBuilt(true);
+        Run<?, ?> run = new RunStub(Result.FAILURE);
+
+        // when
+        boolean matched = condition.matches(run, null);
+
+        // then
+        assertThat(matched).isFalse();
+    }
+
+
+    @Test
     public void match_OnMatchNotBuiltAndResultNotBuilt_ReturnsTrue() throws IOException {
 
         // given


### PR DESCRIPTION
When build result is `null`, treat as equivalent to `Result.NOT_BUILT`.

This covers the final possible result state of `null`, which may exist for new builds that do not have have any result set.

This is a continuation of issue #69.

This follows PR #70, adding the final possible state.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
