### PR TITLE
Stop testing Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@
 buildPlugin(
   useContainerAgent: true,
   failFast: false,  
-  platforms: ['linux', 'windows'],
-  jdkVersions: [11]
-)
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])


### PR DESCRIPTION
JDK 11 has stopped being supported https://www.jenkins.io/doc/book/platform-information/support-policy-java/