### PR TITLE
Stop testing Java 11 - appveyor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,10 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: adopt
 
+      # requires by org.jenkins-ci.plugins:plugin:5.x
+      # can be deleted when default maven will be upgraded from 3.8.*
+      - uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.9
+
       - run: mvn --batch-mode verify

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
-image: Visual Studio 2019
+# https://www.appveyor.com/docs/windows-images-software
+image: Visual Studio 2022
 version: '{build}'
 
 init:
@@ -9,9 +10,9 @@ environment:
     # https://stackoverflow.com/questions/42024619/maven-build-gets-connection-reset-when-downloading-artifacts
     MAVEN_OPTS: "-Dhttp.keepAlive=false -Dmaven.wagon.http.retryHandler.count=3"
   matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk11
+    - JAVA_HOME: C:\Program Files\Java\jdk17
 
 build_script:
-  - mvn clean package --batch-mode -DskipTest
+  - mvn --batch-mode clean package -DskipTest
 test_script:
-  - mvn clean verify --batch-mode
+  - mvn --batch-mode clean verify


### PR DESCRIPTION
Solves **Unknown packaging: hpi** thrown by github actions due to older maven version installed
```
 Error: ] Some problems were encountered while processing the POMs:
Error:  Unknown packaging: hpi @ org.jenkins-ci.plugins:build-history-manager:${revision}${changelist}, /home/runner/work/build-history-manager-plugin/build-history-manager-plugin/pom.xml, line 14, column 16
 @ 
Error:  The build could not read 1 project -> [Help 1]
Error:    
Error:    The project org.jenkins-ci.plugins:build-history-manager:5.7.1-SNAPSHOT (/home/runner/work/build-history-manager-plugin/build-history-manager-plugin/pom.xml) has 1 error
Error:      Unknown packaging: hpi @ org.jenkins-ci.plugins:build-history-manager:${revision}${changelist}, /home/runner/work/build-history-manager-plugin/build-history-manager-plugin/pom.xml, line 14, column 16
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
Error: Process completed with exit code 1.
```